### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The plugin can be built on Windows, macOS, and Linux platforms. The build proces
 Both Mac OSX and Linux rely on Conan for dependencies. Install Conan, e.g. `pip install conan`, and install the dependencies:
 ```sh
 $ conan profile detect --force
-$ conan install . --output-folder=./build_conan --build=missing -g CMakeDeps
+$ conan install . --update --output-folder=./build_conan --build=missing -g CMakeDeps
 ```
 
 ### Mac OSX


### PR DESCRIPTION
I had to run conan install with `--update` to fetch the latest revision of abseil, which is needed because building on ARM macOS is broken on older revisions, see here: https://github.com/conan-io/conan-center-index/issues/25747. `--update` ensures that the latest revision of abseil is fetched