### PR TITLE
Fix old macos version build issue

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -1,11 +1,11 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "30.1.2",
-            "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
+            "version": "cce189011eea744d8af0dc0e03ec4ebc80bde2b0",
+            "baseUrl": "https://github.com/obsproject/obs-studio/archive",
             "label": "OBS sources",
             "hashes": {
-                "macos": "490bae1c392b3b344b0270afd8cb887da4bc50bd92c0c426e96713c1ccb9701a",
+                "macos": "1a80bd1188e6d6408500a1d2627a085add82364dc5568d3ed132e1ac826534b0",
                 "windows-x64": "c2dd03fa7fd01fad5beafce8f7156da11f9ed9a588373fd40b44a06f4c03b867"
             }
         },

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -78,7 +78,7 @@ function(_setup_obs_studio)
     COMMAND
       "${CMAKE_COMMAND}" -S "${dependencies_dir}/${_obs_destination}" -B
       "${dependencies_dir}/${_obs_destination}/build_${arch}" -G ${_cmake_generator} "${_cmake_arch}"
-      -DOBS_CMAKE_VERSION:STRING=${_cmake_version} -DENABLE_PLUGINS:BOOL=OFF -DENABLE_UI:BOOL=OFF
+      -DOBS_CMAKE_VERSION:STRING=${_cmake_version} -DENABLE_PLUGINS:BOOL=OFF -DENABLE_FRONTEND:BOOL=OFF
       -DOBS_VERSION_OVERRIDE:STRING=${_obs_version} "-DCMAKE_PREFIX_PATH='${CMAKE_PREFIX_PATH}'" ${_is_fresh}
       ${_cmake_extra}
     RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
@@ -196,7 +196,7 @@ function(_check_dependencies)
     elseif(dependency STREQUAL qt6)
       list(APPEND CMAKE_PREFIX_PATH "${dependencies_dir}/${destination}")
     elseif(dependency STREQUAL obs-studio)
-      set(_obs_version ${version})
+      set(_obs_version "31.0.3")
       set(_obs_destination "${destination}")
       list(APPEND CMAKE_PREFIX_PATH "${dependencies_dir}")
 

--- a/src/cloudvocal-utils.cpp
+++ b/src/cloudvocal-utils.cpp
@@ -24,7 +24,7 @@ void create_obs_text_source_if_needed()
 #endif
 	if (source) {
 		// add source to the current scene
-		obs_scene_add(scene, source);
+		obs_sceneitem_t *source_sceneitem = obs_scene_add(scene, source);
 		// set source settings
 		obs_data_t *source_settings = obs_source_get_settings(source);
 		obs_data_set_bool(source_settings, "word_wrap", true);
@@ -56,7 +56,6 @@ void create_obs_text_source_if_needed()
 		transform_info.scale.x = 1.0;
 		transform_info.scale.y = 1.0;
 		transform_info.rot = 0.0;
-		obs_sceneitem_t *source_sceneitem = obs_scene_sceneitem_from_source(scene, source);
 		obs_sceneitem_set_info2(source_sceneitem, &transform_info);
 		obs_sceneitem_release(source_sceneitem);
 


### PR DESCRIPTION
I wasn't able to build the plugin on my mac, which is on 15.3.2, the reason for this was that OBS didn't build, probably because the developer tools being too new, which messed up some of the CMake SDK selection.

I noticed this got fixed upstream just a few weeks ago in https://github.com/obsproject/obs-studio/commit/8f1bcc179869ee864ab0dee70dc3ccdf6bec9e11, this is why I bumped the obs-studio dependency to install from a recent commit.

On that recent commit it looks like the CMake arg `ENABLE_UI` got renamed to `ENABLE_FRONTEND`, and the function `obs_scene_sceneitem_from_source` got deprecated, which I found an alternative for