### PR TITLE
Fix race condition in processResults

### DIFF
--- a/src/cloud-providers/cloud-provider.h
+++ b/src/cloud-providers/cloud-provider.h
@@ -104,7 +104,11 @@ protected:
 
 	void processResults()
 	{
-		while (running && !stop_requested) {
+		while (!stop_requested) {
+			if (!running) {
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
+				continue;
+			}
 			readResultsFromTranscription();
 		}
 


### PR DESCRIPTION
There could be a race condition in the `processResults` function. If this is run in a thread and transcription isn't running yet `while (running && !stop_requested)` will immediately be false and thus exit the thread before ever calling processResults.