### PR TITLE
Use min and max sub duration in Closed Captions

### DIFF
--- a/src/cloudvocal-callbacks.cpp
+++ b/src/cloudvocal-callbacks.cpp
@@ -178,12 +178,15 @@ void send_caption_to_stream(DetectionResultWithText result, const std::string &s
 			    struct cloudvocal_data *gf)
 {
 	obs_output_t *streaming_output = obs_frontend_get_streaming_output();
-	if (streaming_output) {
+	if (streaming_output && str_copy.length() > 0) {
 		// calculate the duration in seconds
 		const double duration =
 			(double)(result.end_timestamp_ms - result.start_timestamp_ms) / 1000.0;
 		// prevent the duration from being too short or too long
-		const double effective_duration = std::min(std::max(2.0, duration), 7.0);
+		const double min_duration = static_cast<double>(gf->min_sub_duration) / 1000.0f;
+		const double max_duration = static_cast<double>(gf->max_sub_duration) / 1000.0f;
+		const double effective_duration =
+			std::min(std::max(min_duration, duration), max_duration);
 		obs_log(gf->log_level,
 			"Sending caption to streaming output: %s (raw duration %.3f, effective duration %.3f)",
 			str_copy.c_str(), duration, effective_duration);

--- a/src/cloudvocal-properties.cpp
+++ b/src/cloudvocal-properties.cpp
@@ -226,7 +226,7 @@ void add_advanced_group_properties(obs_properties_t *ppts, struct cloudvocal_dat
 	obs_properties_add_bool(advanced_config_group, "process_while_muted",
 				MT_("process_while_muted"));
 	obs_properties_add_int_slider(advanced_config_group, "min_sub_duration",
-				      MT_("min_sub_duration"), 1000, 5000, 50);
+				      MT_("min_sub_duration"), 300, 5000, 50);
 	obs_properties_add_int_slider(advanced_config_group, "max_sub_duration",
 				      MT_("max_sub_duration"), 1000, 5000, 50);
 
@@ -402,7 +402,7 @@ void cloudvocal_defaults(obs_data_t *s)
 	obs_data_set_default_bool(s, "truncate_output_file", false);
 	obs_data_set_default_bool(s, "only_while_recording", false);
 	obs_data_set_default_bool(s, "rename_file_to_match_recording", true);
-	obs_data_set_default_int(s, "min_sub_duration", 1000);
+	obs_data_set_default_int(s, "min_sub_duration", 500);
 	obs_data_set_default_int(s, "max_sub_duration", 3000);
 	obs_data_set_default_bool(s, "advanced_settings", false);
 	obs_data_set_default_bool(s, "partial_group", true);


### PR DESCRIPTION
I noticed there are configuration options for min and max durations to show the captions. However, it looks like they aren't used currently. I went ahead and changed the min/max hardcoded defaults to use the configurable settings. Also I lowered the minimum to be 300ms because short utterances like interjections might stay longer than intended.