### PR TITLE
Default to caption to stream

### DIFF
--- a/src/cloudvocal-properties.cpp
+++ b/src/cloudvocal-properties.cpp
@@ -393,7 +393,7 @@ void cloudvocal_defaults(obs_data_t *s)
 
 	obs_data_set_default_int(s, "log_level", LOG_DEBUG);
 	obs_data_set_default_bool(s, "log_words", false);
-	obs_data_set_default_bool(s, "caption_to_stream", false);
+	obs_data_set_default_bool(s, "caption_to_stream", true);
 	obs_data_set_default_string(s, "transcription_language_select", "__en__");
 	obs_data_set_default_string(s, "transcription_cloud_provider", "clova");
 	obs_data_set_default_string(s, "subtitle_sources", "none");


### PR DESCRIPTION
I think it makes more sense to caption to stream by default, because it's not that obvious to need to tick the checkbox in the Advanced section for new users.